### PR TITLE
Add specific month summary

### DIFF
--- a/java/ExpenseTracker/README.md
+++ b/java/ExpenseTracker/README.md
@@ -37,16 +37,22 @@ $ cd java/ExpenseTracker
 $ mvn clean package
 
 # Add an expense with a amount and description 
-$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --add 150 "Game"
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --a 150 "Game"
 
 # Update an expense by id 
-$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --update <id> <amount> <description>
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --u <id> <amount> <description>
 
 # Delete an expense by id 
-$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --delete <id>
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --d <id>
 
-# View a summary of all expenses
-$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --summary
+# Show a summary of all expenses
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --s
+
+# Show all expenses
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --l
+
+# Show an expense summary for a specific month
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar --m <specific month (1-12)>
 ```
 
 ## Credits

--- a/java/ExpenseTracker/expenses.json
+++ b/java/ExpenseTracker/expenses.json
@@ -1,1 +1,0 @@
-[{"id":1,"amount":310.0,"description":"wall"}]

--- a/java/ExpenseTracker/src/main/java/com/azvtech/Expense.java
+++ b/java/ExpenseTracker/src/main/java/com/azvtech/Expense.java
@@ -1,19 +1,22 @@
 package com.azvtech;
 
-public class Expense {
-    private static int idCounter = 1;
+import java.time.LocalDate;
+import java.util.UUID;
 
-    private final int id;
+public class Expense {
+    private final UUID id;
     private double amount;
     private String description;
+    private LocalDate date;
 
     public Expense(double amount, String description) {
-        this.id = idCounter++;
+        this.id = UUID.randomUUID();
         this.amount = amount;
         this.description = description;
+        this.date = LocalDate.now();
     }
 
-    public int getId() {
+    public UUID getId() {
         return id;
     }
 
@@ -33,8 +36,16 @@ public class Expense {
         this.description = description;
     }
 
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
     @Override
     public String toString() {
-        return "Expense{id=" + id + ", amount=" + amount + ", description='" + description + "'}";
+        return "Expense{id=" + id + ", amount=" + amount + ", description='" + description + "', date=" + date + "}";
     }
 }

--- a/java/ExpenseTracker/src/main/java/com/azvtech/LocalDateAdapter.java
+++ b/java/ExpenseTracker/src/main/java/com/azvtech/LocalDateAdapter.java
@@ -1,0 +1,30 @@
+package com.azvtech;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * A custom TypeAdapter for serializing and deserializing LocalDate objects with Gson.
+ *
+ * This class provides the functionality to convert LocalDate objects to their
+ * JSON representation and back. It uses the ISO_LOCAL_DATE format for date
+ * representation.
+ */
+public class LocalDateAdapter extends TypeAdapter<LocalDate> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public void write(JsonWriter jsonWriter, LocalDate localDate) throws IOException {
+        jsonWriter.value(localDate.format(formatter));
+    }
+
+    @Override
+    public LocalDate read(JsonReader jsonReader) throws IOException {
+        return LocalDate.parse(jsonReader.nextString(), formatter);
+    }
+}


### PR DESCRIPTION
Feat: Add specific month summary, use UUIDs to uniquely identify expenses and include LocalDateAdapter

- **Monthly Summary:**
   - Added a new feature to `ExpenseTracker` to show an expense summary for a specific month:
   - Implemented the `--month-summary` (`-m`) parameter to filter expenses by month.
   - Displayed total expenses and itemized details of expenses for the specified month.
   
- **Uniquely Identify:**
  - Enhanced the `Expense` class to generate a random UUID for each expense, ensuring globally unique identifiers.
  - Updated the `ExpenseTracker` class to handle UUIDs for adding, updating, and deleting expenses.
  - Removed the need for a static idCounter, simplifying the ID generation logic.
  - Ensured UUIDs are used consistently across interactions, including methods for listing and finding expenses by ID.
  - Adapted JSON serialization/deserialization to support the new UUID format. 
  
- **Local Date Adapter:**
  - Included `LocalDateAdapter` class to handle JSON serialization and deserialization of `LocalDate` objects:
  - Ensured proper formatting and parsing of `LocalDate` when saving to and loading from JSON files.

These updates provide both a robust solution to avoid reflective access issues and add the functionality to view a summary of expenses for a specific month. 

 