### PR TITLE
feat: Add monthly budget setting and warning for budget exceedance

### DIFF
--- a/java/ExpenseTracker/README.md
+++ b/java/ExpenseTracker/README.md
@@ -62,6 +62,9 @@ $ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar -m <spe
 # Filter expenses by category
 $ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar -c <category>
 
+# set a budget for a specific month.
+$ java -jar target/ExpenseTracker-1.0-SNAPSHOT-jar-with-dependencies.jar -b <month> <amount>
+
 
 ```
 


### PR DESCRIPTION
- Introduced a new command-line parameter `--set-budget` (or `-b`) to allow users to set a budget for a specific month.
- Implemented a method to store the budget for each month in a `monthlyBudgets` map.
- Added functionality to calculate total expenses for a given month.
- Integrated a check to warn users when their expenses for a month exceed the set budget.
- Updated the `main` method to handle the new set budget parameter and provide budget exceedance warnings.